### PR TITLE
change to fs.existsSync with backwards compatibility

### DIFF
--- a/tasks/grunt-rm.js
+++ b/tasks/grunt-rm.js
@@ -2,18 +2,21 @@
 module.exports = function (grunt) {
   grunt.registerMultiTask('rm', 'Removes specified files', function () {
     var fs = require('fs');
-    var path = require('path');    
+    var path = require('path');
     var rimraf = require('rimraf');
     var data = this.data;
 
     grunt.log.subhead('Removing ' + this.target + '...');
 
     if (data.dir && fs.statSync(data.dir).isDirectory()) {
-      rimraf.sync(data.dir);      
+      rimraf.sync(data.dir);
       grunt.log.ok('Directory removed: ' + data.dir)
     } else {
-      grunt.file.expandFiles(data).forEach(function (src) {      
-        if (!path.existsSync(src)) {
+      grunt.file.expandFiles(data).forEach(function (src) {
+        // avoid using deprecated path function but maintain
+        // backwards compatability
+        var existsSync = fs.existsSync || path.existsSync;
+        if (!existsSync(src)) {
           return;
         }
         fs.unlinkSync(src);


### PR DESCRIPTION
path.existsSync is deprecated as of Node 0.7+, and generates a warning message during the task execution.

This detects if fs.existsSync exists and uses that, otherwise it reverts to the old method to maintain backwards compatibility.

more info here:
http://stackoverflow.com/questions/4482686/check-synchronously-if-file-directory-exists-in-node-js

Hope this helps!
